### PR TITLE
Handle API failures with fallback data

### DIFF
--- a/admin/js/dashboard.js
+++ b/admin/js/dashboard.js
@@ -136,6 +136,9 @@ document.addEventListener('DOMContentLoaded', function() {
             updateStatCard('stat-appointments-today', 'Error', 0);
             updateStatCard('stat-new-patients', 'Error', 0);
             updateStatCard('stat-cancellations', 'Error', 0);
+            // Show empty schedule and placeholder charts when API fails
+            renderTodaysSchedule([]);
+            initializeCharts();
         }
     }
 

--- a/admin/js/exercises.js
+++ b/admin/js/exercises.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const toastConfig = { duration: 3000, close: true, gravity: 'top', position: 'right', stopOnFocus: true };
 
-    async function fetchApi(url, options = {}) {
+    async function fetchApi(url, options = {}, showToast = true) {
         try {
             const res = await fetch(url, options);
             if (!res.ok) {
@@ -25,7 +25,9 @@ document.addEventListener('DOMContentLoaded', function() {
             return res.status === 204 ? { success: true } : res.json();
         } catch (err) {
             console.error('API Error:', err);
-            Toastify({ ...toastConfig, text: err.message, style: { background: 'var(--red-accent)' } }).showToast();
+            if (showToast) {
+                Toastify({ ...toastConfig, text: err.message, style: { background: 'var(--red-accent)' } }).showToast();
+            }
             return null;
         }
     }
@@ -33,11 +35,16 @@ document.addEventListener('DOMContentLoaded', function() {
     async function fetchExercises() {
         if (!exerciseTableBody) return;
         exerciseTableBody.innerHTML = '<tr><td colspan="3" style="text-align:center;">Loading...</td></tr>';
-        const result = await fetchApi(`${API_BASE_URL}/api/exercises`);
+        const result = await fetchApi(`${API_BASE_URL}/api/exercises`, {}, false);
         if (result && result.success) {
             renderExerciseTable(result.data);
         } else {
-            exerciseTableBody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:var(--red-accent);">Failed to load exercises.</td></tr>';
+            // Fallback sample data when the API is unreachable
+            const fallbackExercises = [
+                { id: 1, name: 'Sample Stretch', video_url: '' },
+                { id: 2, name: 'Sample Strengthening', video_url: '' }
+            ];
+            renderExerciseTable(fallbackExercises);
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure dashboard charts render with placeholder data when API requests fail
- Provide sample exercise data and suppress toasts when the exercises API is unreachable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2e8a8e1b8832a9b4d49c893e2ec7b