### PR TITLE
fix: use deployed API base URL for admin

### DIFF
--- a/admin/js/global.js
+++ b/admin/js/global.js
@@ -1,4 +1,6 @@
-const API_BASE_URL = 'http://localhost:3000';
+// Base URL for API requests. Using the deployed API rather than localhost
+// ensures the admin portal works in production environments.
+const API_BASE_URL = 'https://kheng-physiocare-api.onrender.com';
 
 // admin/js/global.js
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- point admin portal requests to the deployed API instead of localhost

## Testing
- `npm test` (fails: ENOENT no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_b_68a318dc8c54832aa2f487e80ff3b913