### PR TITLE
Handle non-JSON API responses in patient portal login

### DIFF
--- a/js/patient-portal.js
+++ b/js/patient-portal.js
@@ -15,6 +15,17 @@ const exerciseList = document.getElementById('exercise-list');
 
 loginForm.addEventListener('submit', handleLogin);
 
+// Safely parse JSON responses. Returns `null` when response is not valid JSON.
+async function safeJsonParse(response) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    console.warn('Non-JSON response received', text);
+    return null;
+  }
+}
+
 // If a patient is already stored, go straight to the dashboard
 const storedPatient = localStorage.getItem('currentPatient');
 if (storedPatient) {
@@ -46,9 +57,13 @@ async function handleLogin(event) {
       body: JSON.stringify({ email, password })
     });
 
-    const result = await response.json();
-    if (!response.ok || !result.success) {
-      throw new Error(result.message || 'Login failed');
+    const result = await safeJsonParse(response);
+    if (!response.ok || !result || !result.success) {
+      const message =
+        result && (result.message || result.error)
+          ? result.message || result.error
+          : 'Login failed';
+      throw new Error(message);
     }
 
     const patient = result.patient || result.user || result.data;
@@ -67,9 +82,9 @@ async function loadDashboard(patient) {
 
   try {
     const response = await fetch(`${API_BASE_URL}/api/patients/${patient.id}`);
-    const result = await response.json();
+    const result = await safeJsonParse(response);
     if (response.ok && result && result.success) {
-      const data = result.data;
+      const data = result.data || {};
       renderAppointments(data.appointments || []);
       renderExercises(data.exercises || data.assigned_exercises || []);
     } else {


### PR DESCRIPTION
## Summary
- Avoid JSON.parse errors when API returns non-JSON responses
- Display meaningful login errors and fail gracefully on malformed patient data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a330eb6cb4832ab49933fceb344870