### PR TITLE
feat: add mobile-friendly sidebar to admin pages

### DIFF
--- a/admin/appointments.html
+++ b/admin/appointments.html
@@ -28,9 +28,13 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
         <main class="main-content">
             <header class="top-bar">
-                <div class="top-bar-left"><h1 class="page-title" data-i18n="appointments">Appointments</h1></div>
+                <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
+                    <h1 class="page-title" data-i18n="appointments">Appointments</h1>
+                </div>
                 <div class="top-bar-right">
                     <select id="language-select" onchange="setLanguage(this.value)" class="language-select">
                         <option value="en">🇺🇸</option>

--- a/admin/billing.html
+++ b/admin/billing.html
@@ -27,10 +27,12 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <main class="main-content">
             <header class="top-bar">
                 <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
                     <h1 class="page-title" data-i18n="billing">Billing</h1>
                 </div>
                 <div class="top-bar-right">

--- a/admin/css/admin-style.css
+++ b/admin/css/admin-style.css
@@ -142,6 +142,10 @@ html[lang="km"] body {
     flex-shrink: 0;
 }
 
+.sidebar-overlay {
+    display: none;
+}
+
 .sidebar-header {
     display: flex;
     align-items: center;
@@ -218,6 +222,21 @@ html[lang="km"] body {
 .page-title {
     font-size: 2rem;
     font-weight: 700;
+}
+
+.top-bar-left {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.sidebar-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 1.5rem;
+    cursor: pointer;
 }
 
 .top-bar-right {
@@ -371,22 +390,6 @@ html[lang="km"] body {
     .card-span-3 {
         grid-column: span 2;
     }
-}
-@media (max-width: 768px) {
-    .admin-wrapper { flex-direction: column; }
-    .sidebar { width: 100%; height: auto; flex-direction: row; justify-content: space-between; align-items: center; }
-    .sidebar-menu { display: flex; flex-direction: row; margin: 0; }
-    .sidebar-menu .menu-item span { display: none; } /* Hide text, show only icons */
-    .sidebar-menu .menu-item a { border-left: none; }
-    .sidebar-divider { display: none; }
-
-    .top-bar { flex-direction: column; align-items: flex-start; gap: 15px; }
-    .top-bar-right { width: 100%; }
-    .search-box { flex-grow: 1; }
-    .search-box input { width: 100%; }
-    
-    .dashboard-grid { grid-template-columns: 1fr; }
-    .card-span-2, .card-span-3 { grid-column: span 1; }
 }
 
 /* --- Patient Management Page Styles --- */
@@ -925,6 +928,36 @@ html[lang="km"] body {
 
 /* For Mobile Phones (<= 768px) */
 @media (max-width: 768px) {
+    .admin-wrapper {
+        display: block;
+    }
+    .sidebar {
+        position: fixed;
+        top: 0;
+        left: -260px;
+        height: 100%;
+        z-index: 1000;
+        transition: left 0.3s ease;
+    }
+    .sidebar.active {
+        left: 0;
+    }
+    .sidebar-overlay {
+        display: none;
+    }
+    .sidebar-overlay.active {
+        display: block;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 999;
+    }
+    .sidebar-toggle {
+        display: block;
+    }
     .main-content {
         padding: 20px;
     }

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -50,12 +50,14 @@
                 </li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <!-- =========== MAIN CONTENT =========== -->
         <main class="main-content">
             <!-- Top Bar -->
             <header class="top-bar">
                 <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
                     <h1 class="page-title" data-i18n="dashboard">Dashboard</h1>
                 </div>
                 <div class="top-bar-right">

--- a/admin/exercises.html
+++ b/admin/exercises.html
@@ -28,10 +28,14 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <main class="main-content">
             <header class="top-bar">
-                <div class="top-bar-left"><h1 class="page-title" data-i18n="exercises">Exercises</h1></div>
+                <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
+                    <h1 class="page-title" data-i18n="exercises">Exercises</h1>
+                </div>
                 <div class="top-bar-right">
                     <select id="language-select" onchange="setLanguage(this.value)" class="language-select">
                         <option value="en">🇺🇸</option>

--- a/admin/inventory.html
+++ b/admin/inventory.html
@@ -31,11 +31,13 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <!-- =========== MAIN CONTENT =========== -->
         <main class="main-content">
             <header class="top-bar">
                 <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
                     <h1 class="page-title" data-i18n="inventory">Inventory</h1>
                 </div>
                 <div class="top-bar-right">

--- a/admin/js/global.js
+++ b/admin/js/global.js
@@ -2,6 +2,20 @@ const API_BASE_URL = 'https://kheng-physiocare-api.onrender.com';
 
 // admin/js/global.js
 document.addEventListener('DOMContentLoaded', function() {
+    const sidebar = document.querySelector('.sidebar');
+    const sidebarToggle = document.querySelector('.sidebar-toggle');
+    const sidebarOverlay = document.querySelector('.sidebar-overlay');
+    if (sidebar && sidebarToggle && sidebarOverlay) {
+        sidebarToggle.addEventListener('click', () => {
+            sidebar.classList.toggle('active');
+            sidebarOverlay.classList.toggle('active');
+        });
+        sidebarOverlay.addEventListener('click', () => {
+            sidebar.classList.remove('active');
+            sidebarOverlay.classList.remove('active');
+        });
+    }
+
     const userProfile = document.getElementById('user-profile-container');
     if (!userProfile) return; // Only run if the element exists
 

--- a/admin/patient-detail.html
+++ b/admin/patient-detail.html
@@ -28,10 +28,12 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <main class="main-content">
             <header class="top-bar">
                 <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
                     <a href="patients.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> <span data-i18n="backToPatients">Back to All Patients</span></a>
                 </div>
                 <div class="top-bar-right">

--- a/admin/patients.html
+++ b/admin/patients.html
@@ -27,9 +27,13 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
         <main class="main-content">
             <header class="top-bar">
-                <div class="top-bar-left"><h1 class="page-title" data-i18n="patients">Patients</h1></div>
+                <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
+                    <h1 class="page-title" data-i18n="patients">Patients</h1>
+                </div>
                 <div class="top-bar-right">
                     <select id="language-select" onchange="setLanguage(this.value)" class="language-select">
                         <option value="en">🇺🇸</option>

--- a/admin/settings.html
+++ b/admin/settings.html
@@ -29,11 +29,15 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <!-- =========== MAIN CONTENT =========== -->
         <main class="main-content">
             <header class="top-bar">
-                <div class="top-bar-left"><h1 class="page-title" data-i18n="settings">Settings</h1></div>
+                <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
+                    <h1 class="page-title" data-i18n="settings">Settings</h1>
+                </div>
                 <div class="top-bar-right">
                     <select id="language-select" onchange="setLanguage(this.value)" class="language-select">
                         <option value="en">🇺🇸</option>

--- a/admin/staff.html
+++ b/admin/staff.html
@@ -31,11 +31,13 @@
                 <li class="menu-item"><a href="index.html"><i class="fa-solid fa-right-from-bracket"></i><span data-i18n="logout">Logout</span></a></li>
             </ul>
         </nav>
+        <div class="sidebar-overlay"></div>
 
         <!-- =========== MAIN CONTENT =========== -->
         <main class="main-content">
             <header class="top-bar">
                 <div class="top-bar-left">
+                    <button class="sidebar-toggle"><i class="fa-solid fa-bars"></i></button>
                     <h1 class="page-title" data-i18n="staff">Staff</h1>
                 </div>
                 <div class="top-bar-right">


### PR DESCRIPTION
## Summary
- make sidebar collapsible with a hamburger menu on small screens
- style sidebar and layout for mobile with overlay
- hook up toggle logic globally across admin pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e16d6d94832abf48d6d323b69e32